### PR TITLE
Fix typo in maven dependency, so when people copy paste it from the R…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ As a dependency of your Maven project:
 ```
 <dependency>
    <groupId>io.marioslab.basis</groupId>
-   <artifactId>tempalte</artifactId>
+   <artifactId>template</artifactId>
    <version>1.0</version>
 </dependency>
 ```


### PR DESCRIPTION
The README contains a typo in the maven dependency part. 
It's `tempalte` instead of `template`.

