### PR TITLE
Add the instance of a Customer class instead of String to the context…

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ That's it! Let's explore the templating language, which is much more expressive 
 A template consists of text and code spans. Text spans are any old character sequence. Code spans are character sequences inside `{{` and `}}` which must conform to the templating language syntax. Text and code spans can be freely intermixed, e.g.:
 
 ```
-Dear {{customer.getName()}},
+Dear {{customer}},
 
-Thank you for purchasing {{license.getProductName()}}. Find below your activation codes:
+Thank you for purchasing {{license.productName}}. Find below your activation codes:
 
 {{for index, activationCode in license.activationCodes}}
    {{(index + 1)}}. {{activationCode}}
@@ -107,7 +107,7 @@ public static void main (String[] args) {
    TemplateLoader loader = new ClasspathTemplateLoader();
    Template template = loader.load("/textandcodespans.bt");
    TemplateContext context = new TemplateContext();
-   context.set("customer", new Customer("Mr. Hotzenplotz"));
+   context.set("customer", "Mr. Hotzenplotz");
    context.set("license", new License("Hotzenplotz", new String[] {"3ba34234bcffe", "5bbe77f879000", "dd3ee54324bf3"}));
    System.out.println(template.render(context));
 }

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ public static void main (String[] args) {
    TemplateLoader loader = new ClasspathTemplateLoader();
    Template template = loader.load("/textandcodespans.bt");
    TemplateContext context = new TemplateContext();
-   context.set("customer", "Mr. Hotzenplotz");
+   context.set("customer", new Customer("Mr. Hotzenplotz"));
    context.set("license", new License("Hotzenplotz", new String[] {"3ba34234bcffe", "5bbe77f879000", "dd3ee54324bf3"}));
    System.out.println(template.render(context));
 }


### PR DESCRIPTION
The example has `{{customer.getName}}` but the context has a `String` set as the `customer`, so the call would fail. I changed the customer to be a `new Customer` instance which takes the name as the constructor argument.